### PR TITLE
bump minVers, reorder procs in download recipe, add install recipe(pkg parent)

### DIFF
--- a/Slack/Slack.download.recipe
+++ b/Slack/Slack.download.recipe
@@ -16,7 +16,7 @@
 		<false/>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.2.0</string>
+	<string>0.4.0</string>
 	<key>Process</key>
 	<array>
 		<dict>
@@ -34,8 +34,12 @@
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>slack.zip</string>
+				<string>%NAME%.zip</string>
 			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
 		</dict>
 		<dict>
 			<key>Processor</key>
@@ -56,10 +60,6 @@
 				<key>requirement</key>
 				<string>identifier "com.tinyspeck.slackmacgap" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = BQR82RBBHL</string>
 			</dict>
-		</dict>
-		<dict>
-			<key>Processor</key>
-			<string>EndOfCheckPhase</string>
 		</dict>
 	</array>
 </dict>

--- a/Slack/Slack.install.recipe
+++ b/Slack/Slack.install.recipe
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Installs the current release version of Slack.</string>
+    <key>Identifier</key>
+    <string>com.github.killahquam.install.slack</string>
+    <key>Input</key>
+    <dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>0.4.0</string>
+    <key>ParentRecipe</key>
+    <string>com.github.killahquam.pkg.slack</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>Installer</string>
+        </dict>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
CodeSigVerification requires 3.1+ of autopkg, the ‘endofcheckphase’ should be after… urldownloader checks for a new version. I also added an install recipe. Tested good, should clear up anything remaining things I was hinting at in #1.
