### PR TITLE
Update Slack.download.recipe

### DIFF
--- a/Slack/Slack.download.recipe
+++ b/Slack/Slack.download.recipe
@@ -48,6 +48,8 @@
 			<dict>
 				<key>archive_path</key>
 				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.zip</string>
+				<key>purge_destination</key>
+			    	<true/>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Purge destination directory before unarchiving the zip file. Fixes an issue with CodeSignatureVerification: without purging, files from a previous run may exist within %RECIPE_CACHE_DIR%/%NAME%/%NAME%.app, causing CodeSignatureVerification to fail.
