### PR TITLE
You should not use %NAME% here as it breaks if overridden

### DIFF
--- a/VisualStudioCode/VisualStudioCode.download.recipe
+++ b/VisualStudioCode/VisualStudioCode.download.recipe
@@ -49,7 +49,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Visual Studio Code.app</string>
 				<key>requirement</key>
 				<string>identifier "com.microsoft.VSCode" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = UBF8T346G9</string>
 			</dict>


### PR DESCRIPTION
"Visual Studio Code" needs to be hard coded, in case the %NAME% variable is overridden, otherwise CodeSignatureVerifier cannot find the app.