### PR TITLE
Avoiding %NAME% for non variable path

### DIFF
--- a/VisualStudioCode/VisualStudioCode.download.recipe
+++ b/VisualStudioCode/VisualStudioCode.download.recipe
@@ -49,7 +49,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Visual Studio Code.app</string>
 				<key>requirement</key>
 				<string>identifier "com.microsoft.VSCode" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = UBF8T346G9</string>
 			</dict>


### PR DESCRIPTION
%NAME% is a variable that can be changed by recipe overrides (when for example we want to avoid spaces and caps in our munki repo)

It should not be used on a path related to something not under the recipe control, like the app name once extracted from the downloaded archive