### PR TITLE
Updated Slack.download recipe to accept new zip download

### DIFF
--- a/Slack/Slack.download.recipe
+++ b/Slack/Slack.download.recipe
@@ -27,7 +27,22 @@
 				<key>url</key>
 				<string>%DOWNLOAD_URL%</string>
 				<key>filename</key>
-				<string>%NAME%.dmg</string>
+				<string>%NAME%.zip</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>Unarchiver</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>DmgCreator</string>
+			<key>Arguments</key>
+			<dict>
+				<key>dmg_root</key>
+				<string>%RECIPE_CACHE_DIR%/%NAME%/%NAME%.app</string>
+				<key>dmg_path</key>
+				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.dmg</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Previously the recipe would fail because Slack now provides a zip archive instead of a dmg file.