### PR TITLE
Update VisualStudioCode.download.recipe

### DIFF
--- a/VisualStudioCode/VisualStudioCode.download.recipe
+++ b/VisualStudioCode/VisualStudioCode.download.recipe
@@ -41,6 +41,8 @@
 			<dict>
 				<key>archive_path</key>
 				<string>%RECIPE_CACHE_DIR%/downloads/%NAME%.zip</string>
+				<key>purge_destination</key>
+				<true/>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Make sure no files remain from a previous unpack as the code signature check will fail with additional files.
Fixes #17