### PR TITLE
Fixing Postman.jss.recipe - Adding %pkg_path%

### DIFF
--- a/Postman/Postman.jss.recipe
+++ b/Postman/Postman.jss.recipe
@@ -47,6 +47,8 @@
 						<string>%GROUP_TEMPLATE%</string>
 					</dict>
 				</array>
+				<key>pkg_path</key>
+				<string>%pkg_path%</string>
 				<key>policy_category</key>
 				<string>%POLICY_CATEGORY%</string>
 				<key>policy_template</key>


### PR DESCRIPTION
Added %pkg_path% to recipe, as otherwise without that nothing gets uploaded to JSS.

`JSSImporter: No value supplied for pkg_path, setting default value of: `