### PR TITLE
Remove DISABLE_CODE_SIGNATURE_VERIFICATION input variable

### DIFF
--- a/Slack/Slack.download.recipe
+++ b/Slack/Slack.download.recipe
@@ -12,8 +12,6 @@
 		<string>Slack</string>
 		<key>DOWNLOAD_URL</key>
 		<string>https://slack.com/ssb/download-osx</string>
-		<key>DISABLE_CODE_SIGNATURE_VERIFICATION</key>
-		<false/>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.4.0</string>

--- a/VisualStudioCode/VisualStudioCode.download.recipe
+++ b/VisualStudioCode/VisualStudioCode.download.recipe
@@ -12,8 +12,6 @@
 		<string>Visual Studio Code</string>
 		<key>DOWNLOAD_URL</key>
 		<string>https://go.microsoft.com/fwlink/?LinkID=620882</string>
-		<key>DISABLE_CODE_SIGNATURE_VERIFICATION</key>
-		<false/>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.2.0</string>


### PR DESCRIPTION
Code signature verification is enabled by default for recipes that use CodeSignatureVerifier, so there's no reason to set `DISABLE_CODE_SIGNATURE_VERIFICATION` to false here.