### PR TITLE
Visual Studio Code download URL change from x86 to Universal

### DIFF
--- a/VisualStudioCode/VisualStudioCode.download.recipe
+++ b/VisualStudioCode/VisualStudioCode.download.recipe
@@ -11,7 +11,7 @@
 		<key>NAME</key>
 		<string>Visual Studio Code</string>
 		<key>DOWNLOAD_URL</key>
-		<string>https://go.microsoft.com/fwlink/?LinkID=620882</string>
+		<string>https://go.microsoft.com/fwlink/?LinkID=2156837</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.2.0</string>


### PR DESCRIPTION
Hi!

Visual Studio Code has a Universal build now: [https://code.visualstudio.com](https://code.visualstudio.com). I've only changed the Download URL. I've got the Download URL from: [https://macadmins.software/](https://macadmins.software/).

Haven't doen this a lot, so if someone could double check, that would be really great.

I tried the change in download URL by doing: `autopkg run -v --key "DOWNLOAD_URL=https://go.microsoft.com/fwlink/?LinkID=2156837" VisualStudioCode.munki` and that worked as expected.

Thanks!
Tim