### PR TITLE
Update URL to download the universal Slack app

### DIFF
--- a/Slack/Slack.download.recipe
+++ b/Slack/Slack.download.recipe
@@ -11,7 +11,7 @@
 		<key>NAME</key>
 		<string>Slack</string>
 		<key>DOWNLOAD_URL</key>
-		<string>https://slack.com/ssb/download-osx</string>
+		<string>https://slack.com/ssb/download-osx-universal</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.4.0</string>


### PR DESCRIPTION
Slack has just released the universal version of their app starting with Slack 4.14.0.